### PR TITLE
geom_alt props

### DIFF
--- a/data/421/195/687/421195687.geojson
+++ b/data/421/195/687/421195687.geojson
@@ -510,6 +510,9 @@
     },
     "wof:country":"KM",
     "wof:created":1459009856,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e071995bb10a0f3ef3894791bd88e33",
     "wof:hierarchy":[
         {
@@ -520,7 +523,7 @@
         }
     ],
     "wof:id":421195687,
-    "wof:lastmodified":1566581569,
+    "wof:lastmodified":1582347048,
     "wof:name":"Moroni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/856/322/59/85632259.geojson
+++ b/data/856/322/59/85632259.geojson
@@ -983,7 +983,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes",
-        "naturalearth",
         "naturalearth"
     ],
     "src:geom_via":"quattroshapes",
@@ -1063,7 +1062,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1582347047,
+    "wof:lastmodified":1583226658,
     "wof:name":"Comoros",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/59/85632259.geojson
+++ b/data/856/322/59/85632259.geojson
@@ -982,8 +982,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "quattroshapes",
         "naturalearth",
-        "quattroshapes"
+        "naturalearth"
     ],
     "src:geom_via":"quattroshapes",
     "src:lbl_centroid":"mapshaper",
@@ -1039,6 +1040,11 @@
     },
     "wof:country":"KM",
     "wof:country_alpha3":"COM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"2d7ee2029a70ae09210a078c2020e089",
     "wof:hierarchy":[
         {
@@ -1057,7 +1063,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1566581558,
+    "wof:lastmodified":1582347047,
     "wof:name":"Comoros",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.