### PR TITLE
Name updates

### DIFF
--- a/data/856/322/59/85632259.geojson
+++ b/data/856/322/59/85632259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14028,
-    "geom:area_square_m":1697313752.08791,
+    "geom:area_square_m":1697313493.810444,
     "geom:bbox":"43.226212,-12.421856,44.547905,-11.365994",
     "geom:latitude":-11.895698,
     "geom:longitude":43.686011,
@@ -60,6 +60,9 @@
     "name:arg_x_preferred":[
         "Comoras"
     ],
+    "name:ary_x_preferred":[
+        "\u062c\u0632\u0631 \u0644\u0642\u0648\u0645\u0648\u0631"
+    ],
     "name:arz_x_preferred":[
         "\u062c\u0632\u0631 \u0627\u0644\u0642\u0645\u0631"
     ],
@@ -83,6 +86,9 @@
     ],
     "name:bam_x_variant":[
         "Kom\u0254ri"
+    ],
+    "name:ban_x_preferred":[
+        "Komoros"
     ],
     "name:bcl_x_preferred":[
         "Komoros"
@@ -175,6 +181,12 @@
     "name:dan_x_preferred":[
         "Comorerne"
     ],
+    "name:deu_at_x_preferred":[
+        "Komoren"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Komoren"
+    ],
     "name:deu_x_preferred":[
         "Komoren"
     ],
@@ -199,6 +211,12 @@
     ],
     "name:ell_x_variant":[
         "\u039a\u03bf\u03bc\u03cc\u03c1\u03bf\u03c2"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Comoros"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Comoros"
     ],
     "name:eng_x_preferred":[
         "Comoros"
@@ -281,6 +299,9 @@
     ],
     "name:gag_x_preferred":[
         "Komorlar"
+    ],
+    "name:gcr_x_preferred":[
+        "Komor"
     ],
     "name:gla_x_preferred":[
         "Na h-Eileanan Chomoro"
@@ -544,6 +565,9 @@
     "name:mlt_x_preferred":[
         "Komoros"
     ],
+    "name:mri_x_preferred":[
+        "Komoro"
+    ],
     "name:msa_x_preferred":[
         "Comoros"
     ],
@@ -641,6 +665,9 @@
     "name:pol_x_preferred":[
         "Komory"
     ],
+    "name:por_br_x_preferred":[
+        "Comores"
+    ],
     "name:por_x_preferred":[
         "Comores"
     ],
@@ -707,6 +734,9 @@
     "name:sme_x_variant":[
         "Komorosullot"
     ],
+    "name:smo_x_preferred":[
+        "Comoros"
+    ],
     "name:sna_x_preferred":[
         "Comoros"
     ],
@@ -733,6 +763,12 @@
     ],
     "name:srd_x_preferred":[
         "Comoras"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041a\u043e\u043c\u043e\u0440\u0438"
+    ],
+    "name:srp_el_x_preferred":[
+        "Komori"
     ],
     "name:srp_x_preferred":[
         "\u041a\u043e\u043c\u043e\u0440\u0438"
@@ -890,8 +926,20 @@
     "name:zha_x_preferred":[
         "Comoros"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u79d1\u6469\u7f57"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u79d1\u6469\u7f85"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Komor"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u79d1\u6469\u7f85"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u79d1\u6469\u7f57"
     ],
     "name:zho_x_preferred":[
         "\u845b\u6469"
@@ -1063,7 +1111,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1583797317,
+    "wof:lastmodified":1587428031,
     "wof:name":"Comoros",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.