### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/536/155/102536155.geojson
+++ b/data/102/536/155/102536155.geojson
@@ -19,6 +19,9 @@
     "name:ceb_x_preferred":[
         "Moh\u00e9li Bandar Es Eslam Airport"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Moh\u00e9li Bandar Es Eslam"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Moh\u00e9li Bandar Es Eslam"
     ],
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":102536155,
-    "wof:lastmodified":1631750409,
+    "wof:lastmodified":1690938173,
     "wof:name":"Moheli Bandar Es Salam Airport",
     "wof:parent_id":85670267,
     "wof:placetype":"campus",

--- a/data/112/582/104/9/1125821049.geojson
+++ b/data/112/582/104/9/1125821049.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0634\u0627\u0646\u062f\u0631\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0627\u0646\u062f\u0631\u0627"
+    ],
     "name:bul_x_preferred":[
         "\u0427\u0430\u043d\u0434\u0440\u0430"
     ],
@@ -47,6 +50,9 @@
         "Chandra"
     ],
     "name:ron_x_preferred":[
+        "Chandra"
+    ],
+    "name:swa_x_preferred":[
         "Chandra"
     ],
     "name:swe_x_preferred":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":1125821049,
-    "wof:lastmodified":1566581592,
+    "wof:lastmodified":1690938192,
     "wof:name":"Chandra",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/112/586/553/5/1125865535.geojson
+++ b/data/112/586/553/5/1125865535.geojson
@@ -25,10 +25,16 @@
     "name:ara_x_preferred":[
         "\u0647\u0627\u062c\u0647\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0627\u062c\u0647\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0647\u0627\u062c\u0648\u0647\u0648"
     ],
     "name:ceb_x_preferred":[
+        "Hajoho"
+    ],
+    "name:deu_x_preferred":[
         "Hajoho"
     ],
     "name:eng_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":1125865535,
-    "wof:lastmodified":1566581591,
+    "wof:lastmodified":1690938192,
     "wof:name":"Hajoho",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/112/586/554/5/1125865545.geojson
+++ b/data/112/586/554/5/1125865545.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0647\u0627\u0631\u0645\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0627\u0631\u0645\u0628\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0647\u0627\u0631\u0645\u0628\u0648"
     ],
@@ -32,6 +35,9 @@
         "\u0425\u0430\u0440\u0435\u043c\u0431\u043e"
     ],
     "name:ceb_x_preferred":[
+        "Harembo"
+    ],
+    "name:deu_x_preferred":[
         "Harembo"
     ],
     "name:eng_x_preferred":[
@@ -86,7 +92,7 @@
         }
     ],
     "wof:id":1125865545,
-    "wof:lastmodified":1566581592,
+    "wof:lastmodified":1690938192,
     "wof:name":"Harembo",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/112/586/555/9/1125865559.geojson
+++ b/data/112/586/555/9/1125865559.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u0646\u0643\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0646\u0643\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u0646\u0642\u0648\u0646\u06cc"
     ],
@@ -34,11 +37,17 @@
     "name:ceb_x_preferred":[
         "Lingoni"
     ],
+    "name:deu_x_preferred":[
+        "Lingoni"
+    ],
     "name:eng_x_preferred":[
         "Lingoni"
     ],
     "name:fas_x_preferred":[
         "\u0644\u06cc\u0646\u06af\u0648\u0646\u06cc"
+    ],
+    "name:fra_x_preferred":[
+        "Lingoni"
     ],
     "name:nld_x_preferred":[
         "Lingoni"
@@ -86,7 +95,7 @@
         }
     ],
     "wof:id":1125865559,
-    "wof:lastmodified":1566581591,
+    "wof:lastmodified":1690938191,
     "wof:name":"Lingoni",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/421/167/165/421167165.geojson
+++ b/data/421/167/165/421167165.geojson
@@ -20,10 +20,16 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0645\u0628\u0648\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0645\u0628\u0648\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0424\u043e\u0443\u043c\u0431\u043e\u0443\u043d\u0438"
     ],
     "name:ceb_x_preferred":[
+        "Foumbouni"
+    ],
+    "name:deu_x_preferred":[
         "Foumbouni"
     ],
     "name:eng_x_preferred":[
@@ -40,6 +46,9 @@
     ],
     "name:ita_x_preferred":[
         "Foumbouni"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d5\u30f3\u30d6\u30cb"
     ],
     "name:nld_x_preferred":[
         "Foumbouni"
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":421167165,
-    "wof:lastmodified":1566581569,
+    "wof:lastmodified":1690938174,
     "wof:name":"Foumbouni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/421/170/749/421170749.geojson
+++ b/data/421/170/749/421170749.geojson
@@ -20,7 +20,16 @@
     "name:ara_x_preferred":[
         "\u062f\u0645\u0628\u064a\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0645\u0628\u064a\u0646\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Demb\u00e9ni"
+    ],
     "name:ceb_x_preferred":[
+        "Demb\u00e9ni"
+    ],
+    "name:deu_x_preferred":[
         "Demb\u00e9ni"
     ],
     "name:eng_x_preferred":[
@@ -32,13 +41,22 @@
     "name:hrv_x_preferred":[
         "D\u00e9mbeni"
     ],
+    "name:hun_x_preferred":[
+        "Demb\u00e9ni"
+    ],
     "name:ind_x_preferred":[
         "Demb\u00e9ni"
     ],
     "name:ita_x_preferred":[
         "Demb\u00e9ni"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c7\u30f3\u30d9\u30cb"
+    ],
     "name:nld_x_preferred":[
+        "Demb\u00e9ni"
+    ],
+    "name:pol_x_preferred":[
         "Demb\u00e9ni"
     ],
     "name:ron_x_preferred":[
@@ -96,7 +114,7 @@
         }
     ],
     "wof:id":421170749,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938176,
     "wof:name":"Dembeni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/421/175/747/421175747.geojson
+++ b/data/421/175/747/421175747.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0648\u0645\u0648\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0648\u0645\u0648\u0646\u0649"
+    ],
     "name:bre_x_preferred":[
         "Domoni"
     ],
@@ -68,6 +71,9 @@
     "name:ron_x_preferred":[
         "Domoni"
     ],
+    "name:spa_x_preferred":[
+        "Domoni"
+    ],
     "name:srp_x_preferred":[
         "\u0414\u043e\u043c\u043e\u043d\u0438"
     ],
@@ -76,6 +82,12 @@
     ],
     "name:und_x_variant":[
         "Deumoni"
+    ],
+    "name:vie_x_preferred":[
+        "Domoni"
+    ],
+    "name:zho_x_preferred":[
+        "\u591a\u6469\u5c3c\u5e02"
     ],
     "qs:gn_country":"KM",
     "qs:gn_fcode":"PPL",
@@ -119,7 +131,7 @@
         }
     ],
     "wof:id":421175747,
-    "wof:lastmodified":1566581569,
+    "wof:lastmodified":1690938175,
     "wof:name":"Domoni",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/189/643/421189643.geojson
+++ b/data/421/189/643/421189643.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u0633\u064a\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0645\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Sima"
     ],
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":421189643,
-    "wof:lastmodified":1566581569,
+    "wof:lastmodified":1690938174,
     "wof:name":"Sima",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/421/190/899/421190899.geojson
+++ b/data/421/190/899/421190899.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u062a\u0633\u0627\u0645\u0648\u062f\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u062a\u0633\u0627\u0645\u0648\u062f\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Mutsamudu"
+    ],
     "name:azb_x_preferred":[
         "\u0645\u0648\u062a\u0633\u0627\u0645\u0648\u062f\u0648"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0443\u0446\u0430\u043c\u0443\u0434\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0443\u0446\u0430\u043c\u0443\u0434\u0443"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u099f\u09b8\u09be\u09ae\u09c1\u09a6\u09c1"
@@ -106,6 +115,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092e\u0941\u091f\u094d\u0938\u092e\u0941\u0921\u0942"
+    ],
+    "name:mlg_x_preferred":[
+        "Mutsamudu"
     ],
     "name:msa_x_preferred":[
         "Mutsamudu"
@@ -216,7 +228,7 @@
         }
     ],
     "wof:id":421190899,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938176,
     "wof:name":"Mutsamudu",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/421/190/903/421190903.geojson
+++ b/data/421/190/903/421190903.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0625\u0645\u0628\u064a\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0645\u0628\u064a\u0646\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Mb\u00e9ni"
     ],
@@ -34,6 +40,9 @@
     ],
     "name:ita_x_preferred":[
         "Mb\u00e9ni"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e0\u30d9\u30cb"
     ],
     "name:nld_x_preferred":[
         "Mb\u00e9ni"
@@ -93,7 +102,7 @@
         }
     ],
     "wof:id":421190903,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938175,
     "wof:name":"Mbeni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/421/190/905/421190905.geojson
+++ b/data/421/190/905/421190905.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0641\u0648\u0645\u0628\u0648\u0646\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Fomboni"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0424\u0430\u043c\u0431\u043e\u043d\u0456"
+    ],
+    "name:bel_x_variant":[
+        "\u0424\u0430\u043c\u0431\u043e\u043d\u0456"
     ],
     "name:bre_x_preferred":[
         "Fomboni"
@@ -47,10 +53,16 @@
     "name:fra_x_preferred":[
         "Fomboni"
     ],
+    "name:frr_x_preferred":[
+        "Fomboni"
+    ],
     "name:heb_x_preferred":[
         "\u05e4\u05d5\u05de\u05d1\u05d5\u05e0\u05d9"
     ],
     "name:hrv_x_preferred":[
+        "Fomboni"
+    ],
+    "name:hun_x_preferred":[
         "Fomboni"
     ],
     "name:ind_x_preferred":[
@@ -70,6 +82,9 @@
     ],
     "name:lit_x_preferred":[
         "Fombonis"
+    ],
+    "name:mlg_x_preferred":[
+        "Fomboni"
     ],
     "name:nld_x_preferred":[
         "Fomboni"
@@ -103,6 +118,9 @@
     ],
     "name:und_x_variant":[
         "Fumboni"
+    ],
+    "name:vie_x_preferred":[
+        "Fomboni"
     ],
     "name:zho_x_preferred":[
         "\u8c50\u535a\u5c3c"
@@ -155,7 +173,7 @@
         }
     ],
     "wof:id":421190905,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938176,
     "wof:name":"Fomboni",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/421/191/543/421191543.geojson
+++ b/data/421/191/543/421191543.geojson
@@ -20,10 +20,16 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0631\u064a\u0646\u0643\u0648\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0631\u064a\u0646\u0643\u0648\u0646\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Miringoni"
     ],
     "name:eng_x_preferred":[
+        "Miringoni"
+    ],
+    "name:fra_x_preferred":[
         "Miringoni"
     ],
     "name:nld_x_preferred":[
@@ -78,7 +84,7 @@
         }
     ],
     "wof:id":421191543,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938175,
     "wof:name":"Miringoni",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/421/195/687/421195687.geojson
+++ b/data/421/195/687/421195687.geojson
@@ -22,13 +22,28 @@
     "name:afr_x_preferred":[
         "Moroni"
     ],
+    "name:aka_x_preferred":[
+        "Moroni"
+    ],
     "name:amh_x_preferred":[
         "\u121e\u122e\u1292"
     ],
     "name:ara_x_preferred":[
         "\u0645\u0648\u0631\u0648\u0646\u064a"
     ],
+    "name:arg_x_preferred":[
+        "Moroni"
+    ],
+    "name:ary_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u0646\u0649"
+    ],
     "name:ast_x_preferred":[
+        "Moroni"
+    ],
+    "name:avk_x_preferred":[
         "Moroni"
     ],
     "name:azb_x_preferred":[
@@ -37,11 +52,17 @@
     "name:aze_x_preferred":[
         "Moroni"
     ],
+    "name:bak_x_preferred":[
+        "\u041c\u043e\u0440\u043e\u043d\u0438"
+    ],
     "name:bam_x_preferred":[
         "M\u0254r\u0254ni"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0440\u043e\u043d\u0456"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u0440\u043e\u043d\u0456"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09cb\u09b0\u09cb\u09a8\u09bf"
@@ -86,6 +107,9 @@
         "Moroni"
     ],
     "name:deu_x_preferred":[
+        "Moroni"
+    ],
+    "name:diq_x_preferred":[
         "Moroni"
     ],
     "name:ell_x_preferred":[
@@ -137,6 +161,9 @@
         "Moroni"
     ],
     "name:hat_x_preferred":[
+        "Moroni"
+    ],
+    "name:hau_x_preferred":[
         "Moroni"
     ],
     "name:heb_x_preferred":[
@@ -205,6 +232,9 @@
     "name:lav_x_preferred":[
         "Moroni"
     ],
+    "name:lij_x_preferred":[
+        "Moroni"
+    ],
     "name:lit_x_preferred":[
         "Moronis"
     ],
@@ -220,14 +250,23 @@
     "name:mar_x_preferred":[
         "\u092e\u094b\u0930\u094b\u0928\u0940"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u043e\u0440\u043e\u043d\u0438"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u043e\u0440\u043e\u043d\u0438"
+    ],
+    "name:mlg_x_preferred":[
+        "Moroni"
     ],
     "name:mon_x_preferred":[
         "\u041c\u043e\u0440\u043e\u043d\u0438"
     ],
     "name:msa_x_preferred":[
         "Moroni"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u0646\u06cc"
     ],
     "name:nah_x_preferred":[
         "Moroni"
@@ -253,6 +292,12 @@
     "name:oci_x_preferred":[
         "Mor\u00f2ni"
     ],
+    "name:olo_x_preferred":[
+        "Moroni"
+    ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u0440\u043e\u043d\u0438"
+    ],
     "name:pan_x_preferred":[
         "\u0a2e\u0a4b\u0a30\u0a4b\u0a28\u0a40"
     ],
@@ -267,6 +312,9 @@
     ],
     "name:por_x_preferred":[
         "Moroni"
+    ],
+    "name:pus_x_preferred":[
+        "\u0645\u0648\u0631\u0648\u0646\u06cc"
     ],
     "name:que_x_preferred":[
         "Muruni"
@@ -289,6 +337,9 @@
     "name:slv_x_preferred":[
         "Moroni"
     ],
+    "name:smn_x_preferred":[
+        "Moroni"
+    ],
     "name:sna_x_preferred":[
         "Moroni"
     ],
@@ -299,6 +350,9 @@
         "Moroni"
     ],
     "name:sqi_x_preferred":[
+        "Moroni"
+    ],
+    "name:srd_x_preferred":[
         "Moroni"
     ],
     "name:srp_x_preferred":[
@@ -525,7 +579,7 @@
         }
     ],
     "wof:id":421195687,
-    "wof:lastmodified":1607390893,
+    "wof:lastmodified":1690938174,
     "wof:name":"Moroni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/421/198/505/421198505.geojson
+++ b/data/421/198/505/421198505.geojson
@@ -20,7 +20,13 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u064a\u0627"
+    ],
     "name:ceb_x_preferred":[
+        "Moya"
+    ],
+    "name:deu_x_preferred":[
         "Moya"
     ],
     "name:eng_x_preferred":[
@@ -91,7 +97,7 @@
         }
     ],
     "wof:id":421198505,
-    "wof:lastmodified":1566581569,
+    "wof:lastmodified":1690938175,
     "wof:name":"Moya",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/201/961/421201961.geojson
+++ b/data/421/201/961/421201961.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u062a\u0633\u0627\u0645\u064a\u0648\u0644\u064a"
     ],
+    "name:ara_x_variant":[
+        "\u0645\u064a\u062a\u0633\u0627\u0645\u064a\u0647\u0648\u0644\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u062a\u0633\u0627\u0645\u064a\u0647\u0648\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Mitsamihuli"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0438\u0446\u0430\u043c\u0438\u043e\u0443\u043b\u0438"
     ],
@@ -28,6 +37,9 @@
     ],
     "name:eng_x_preferred":[
         "Mitsamiouli"
+    ],
+    "name:eng_x_variant":[
+        "Mitsamihuli"
     ],
     "name:fra_x_preferred":[
         "Mitsamiouli"
@@ -114,7 +126,7 @@
         }
     ],
     "wof:id":421201961,
-    "wof:lastmodified":1566581570,
+    "wof:lastmodified":1690938176,
     "wof:name":"Mitsamiouli",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/856/322/59/85632259.geojson
+++ b/data/856/322/59/85632259.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u041a\u043e\u043c\u043e\u0440\u0442\u04d9\u0438 \u0410\u0434\u0433\u044c\u044b\u043b\u0431\u0436\u044c\u0430\u0445\u0430\u049b\u04d9\u0430"
+    ],
     "name:afr_x_preferred":[
         "Comore-eilande"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:amh_x_preferred":[
         "\u12ae\u121e\u122e\u1235"
+    ],
+    "name:anp_x_preferred":[
+        "\u0915\u094b\u092e\u094b\u0930\u094b\u091c"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0627\u0644\u0642\u0645\u0631"
@@ -69,6 +75,9 @@
     "name:ast_x_preferred":[
         "Comores"
     ],
+    "name:avk_x_preferred":[
+        "Komoria"
+    ],
     "name:azb_x_preferred":[
         "\u06a9\u0648\u0645\u0648\u0631 \u0622\u062f\u0627\u0644\u0627\u0631\u06cc"
     ],
@@ -89,6 +98,9 @@
     ],
     "name:ban_x_preferred":[
         "Komoros"
+    ],
+    "name:bar_x_preferred":[
+        "Komorn"
     ],
     "name:bcl_x_preferred":[
         "Komoros"
@@ -160,6 +172,9 @@
     "name:che_x_variant":[
         "\u041a\u043e\u043c\u043e\u0440\u0430 \u0413l\u0430\u0439\u0440\u0435\u0448"
     ],
+    "name:chr_x_preferred":[
+        "\u13aa\u13bc\u13b3\u13cd"
+    ],
     "name:chv_x_preferred":[
         "\u041a\u043e\u043c\u043e\u0440 \u0443\u0442\u0440\u0430\u0432\u0115\u0441\u0435\u043c"
     ],
@@ -169,6 +184,9 @@
     "name:cor_x_preferred":[
         "Komorys"
     ],
+    "name:cos_x_preferred":[
+        "Isule Comore"
+    ],
     "name:crh_x_preferred":[
         "Komorlar"
     ],
@@ -176,6 +194,9 @@
         "Y Comoros"
     ],
     "name:cym_x_variant":[
+        "Comoros"
+    ],
+    "name:dag_x_preferred":[
         "Comoros"
     ],
     "name:dan_x_preferred":[
@@ -250,6 +271,9 @@
     "name:ewe_x_variant":[
         "Comoros"
     ],
+    "name:ext_x_preferred":[
+        "Comoras"
+    ],
     "name:fao_x_preferred":[
         "Komoroyggjar"
     ],
@@ -317,6 +341,9 @@
     ],
     "name:gom_x_preferred":[
         "\u0915\u094b\u092e\u094b\u0930\u094b\u0938"
+    ],
+    "name:gpe_x_preferred":[
+        "Comoros"
     ],
     "name:grn_x_preferred":[
         "Kom\u00f3ra"
@@ -472,6 +499,9 @@
         "\ucf54\ubaa8\ub974",
         "\ucf54\ubaa8\ub85c\uc2a4"
     ],
+    "name:krj_x_preferred":[
+        "Kakomorhan"
+    ],
     "name:kur_x_preferred":[
         "Komor"
     ],
@@ -511,6 +541,9 @@
     "name:lit_x_preferred":[
         "Komorai"
     ],
+    "name:lld_x_preferred":[
+        "Comores"
+    ],
     "name:lmo_x_preferred":[
         "Cumor"
     ],
@@ -535,6 +568,9 @@
     "name:lzh_x_preferred":[
         "\u845b\u6469"
     ],
+    "name:mad_x_preferred":[
+        "Komoro"
+    ],
     "name:mal_x_preferred":[
         "\u0d15\u0d4a\u0d2e\u0d4b\u0d31\u0d38\u0d4d"
     ],
@@ -546,6 +582,12 @@
     ],
     "name:mar_x_variant":[
         "\u0915\u094b\u092e\u094b\u0930\u094b\u091c"
+    ],
+    "name:mdf_x_preferred":[
+        "\u041a\u043e\u043c\u043e\u0440\u0442\u043d\u0435"
+    ],
+    "name:mhr_x_preferred":[
+        "\u041a\u0430\u043c\u043e\u0440 \u041e\u0442\u0440\u043e-\u0432\u043b\u0430\u043a"
     ],
     "name:min_x_preferred":[
         "Komoro"
@@ -564,6 +606,15 @@
     ],
     "name:mlt_x_preferred":[
         "Komoros"
+    ],
+    "name:mlt_x_variant":[
+        "Comoros"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc0\uabe3\uabc3\uabe3\uabd4\uabe3\uabc1"
+    ],
+    "name:mon_x_preferred":[
+        "\u041a\u043e\u043c\u043e\u0440"
     ],
     "name:mri_x_preferred":[
         "Komoro"
@@ -662,6 +713,9 @@
     "name:pms_x_preferred":[
         "Com\u00f2re"
     ],
+    "name:pnb_x_preferred":[
+        "\u0627\u062a\u062d\u0627\u062f \u0627\u0644\u0642\u0645\u0631\u06cc"
+    ],
     "name:pol_x_preferred":[
         "Komory"
     ],
@@ -676,6 +730,9 @@
     ],
     "name:pus_x_preferred":[
         "\u06a9\u0648\u0645\u0648\u0631\u0648\u0633"
+    ],
+    "name:pus_x_variant":[
+        "\u0642\u0645\u0631\u067c\u0627\u067e\u0648\u06ab\u0627\u0646"
     ],
     "name:que_x_preferred":[
         "Kumurakuna"
@@ -710,6 +767,9 @@
     "name:san_x_preferred":[
         "\u0915\u094b\u092e\u094b\u0930\u094b\u0938"
     ],
+    "name:sat_x_preferred":[
+        "\u1c60\u1c73\u1c62\u1c73\u1c68\u1c73\u1c65"
+    ],
     "name:scn_x_preferred":[
         "Comori"
     ],
@@ -719,8 +779,14 @@
     "name:sgs_x_preferred":[
         "Kuomor\u0101"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1076\u1030\u101d\u103a\u1087\u1019\u1030\u101d\u103a\u1087\u101b\u1030\u1010\u103a\u1088"
+    ],
     "name:sin_x_preferred":[
         "\u0d9a\u0ddc\u0db8\u0dbb\u0ddc\u0dc3\u0dca"
+    ],
+    "name:skr_x_preferred":[
+        "\u0627\u062a\u062d\u0627\u062f \u06a9\u0648\u0645\u0648\u0631\u0648\u0633"
     ],
     "name:slk_x_preferred":[
         "Komory"
@@ -734,14 +800,23 @@
     "name:sme_x_variant":[
         "Komorosullot"
     ],
+    "name:smn_x_preferred":[
+        "Komoreh"
+    ],
     "name:smo_x_preferred":[
         "Comoros"
+    ],
+    "name:sms_x_preferred":[
+        "Komoor"
     ],
     "name:sna_x_preferred":[
         "Comoros"
     ],
     "name:sna_x_variant":[
         "Komoro"
+    ],
+    "name:snd_x_preferred":[
+        "\u06aa\u0648\u0645\u0648\u0631\u0648\u0633"
     ],
     "name:som_x_preferred":[
         "Komoros"
@@ -829,6 +904,9 @@
     "name:tir_x_preferred":[
         "\u12ae\u121e\u122e\u1235"
     ],
+    "name:tok_x_preferred":[
+        "ma Komo"
+    ],
     "name:ton_x_preferred":[
         "Komolosi"
     ],
@@ -837,6 +915,9 @@
     ],
     "name:tuk_x_preferred":[
         "Komor Adalary"
+    ],
+    "name:tum_x_preferred":[
+        "Comoros"
     ],
     "name:tur_x_preferred":[
         "Komorlar"
@@ -886,6 +967,9 @@
         "C\u00f4-m\u00f4",
         "Comores",
         "C\u00f4-m\u00f4 (Comoros)"
+    ],
+    "name:vls_x_preferred":[
+        "Comoorn"
     ],
     "name:vol_x_preferred":[
         "Komoru\u00e4ns"
@@ -1176,7 +1260,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1617827544,
+    "wof:lastmodified":1690938173,
     "wof:name":"Comoros",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/702/67/85670267.geojson
+++ b/data/856/702/67/85670267.geojson
@@ -81,6 +81,9 @@
     "name:eus_x_preferred":[
         "Moheli"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u0647\u0644\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Moh\u00e9li"
     ],
@@ -103,6 +106,9 @@
         "\u092e\u094b\u0939\u0932\u0940"
     ],
     "name:hrv_x_preferred":[
+        "Moh\u00e9li"
+    ],
+    "name:hun_x_preferred":[
         "Moh\u00e9li"
     ],
     "name:ind_x_preferred":[
@@ -131,6 +137,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092e\u094b\u0939\u0940\u0932\u093f"
+    ],
+    "name:mlg_x_preferred":[
+        "Moaly"
     ],
     "name:msa_x_preferred":[
         "Moh\u00e9li"
@@ -323,7 +332,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1614893624,
+    "wof:lastmodified":1690938173,
     "wof:name":"Mo\u00fbh\u00eel\u00ee",
     "wof:parent_id":85632259,
     "wof:placetype":"region",

--- a/data/856/702/77/85670277.geojson
+++ b/data/856/702/77/85670277.geojson
@@ -37,6 +37,9 @@
         "\u0647\u0646\u0632\u0648\u0627\u0646",
         "Anjouan"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0646\u062c\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
         "Anjouan"
     ],
@@ -147,6 +150,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0905\u0902\u091c\u0941\u0906\u0928"
+    ],
+    "name:mlg_x_preferred":[
+        "Njoany"
     ],
     "name:msa_x_preferred":[
         "Anjouan"
@@ -354,7 +360,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1614893624,
+    "wof:lastmodified":1690938174,
     "wof:name":"Andjou\u00e2n",
     "wof:parent_id":85632259,
     "wof:placetype":"region",

--- a/data/890/415/411/890415411.geojson
+++ b/data/890/415/411/890415411.geojson
@@ -19,11 +19,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u062c\u0627\u0645\u0648\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u062c\u0627\u0645\u0648\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Mjamaou\u00e9"
     ],
     "name:eng_x_preferred":[
         "Mjamaoue"
+    ],
+    "name:fra_x_preferred":[
+        "Mjamaou\u00e9"
     ],
     "name:nld_x_preferred":[
         "Mjamaoue"
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890415411,
-    "wof:lastmodified":1566581574,
+    "wof:lastmodified":1690938180,
     "wof:name":"Mjamaou\u00e9",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/413/890415413.geojson
+++ b/data/890/415/413/890415413.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0647\u0627\u0631\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u0627\u0647\u0627\u0631\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Marahar\u00e9"
     ],
@@ -61,7 +67,7 @@
         }
     ],
     "wof:id":890415413,
-    "wof:lastmodified":1566581572,
+    "wof:lastmodified":1690938178,
     "wof:name":"Marahar\u00e9",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/415/415/890415415.geojson
+++ b/data/890/415/415/890415415.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0646\u064a \u062c\u0648\u062c\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0646\u0649 \u062c\u0648\u062c\u0648"
+    ],
     "name:ceb_x_preferred":[
         "Koni-Djodjo"
     ],
@@ -42,6 +48,9 @@
     ],
     "name:ita_x_preferred":[
         "Koni-Djodjo"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b3\u30cb\uff1d\u30b8\u30e7\u30b8\u30e7"
     ],
     "name:nld_x_preferred":[
         "Koni-Djodjo"
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":890415415,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938178,
     "wof:name":"Koni-Djodjo",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/417/890415417.geojson
+++ b/data/890/415/417/890415417.geojson
@@ -19,14 +19,29 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0646\u064a \u0646\u062c\u0627\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0646\u0649 \u0646\u062c\u0627\u0646\u0649"
+    ],
+    "name:ceb_x_preferred":[
+        "Koni-Ngani"
+    ],
     "name:deu_x_preferred":[
         "Koni Ngani"
     ],
     "name:eng_x_preferred":[
         "Koni Ngani"
     ],
+    "name:fra_x_preferred":[
+        "Koni Ngani"
+    ],
     "name:nld_x_preferred":[
         "Koni Ngani"
+    ],
+    "name:swe_x_preferred":[
+        "Koni-Ngani"
     ],
     "name:und_x_variant":[
         "Kone N\u2019Goni"
@@ -62,7 +77,7 @@
         }
     ],
     "wof:id":890415417,
-    "wof:lastmodified":1566581574,
+    "wof:lastmodified":1690938179,
     "wof:name":"Koni-Ngani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/419/890415419.geojson
+++ b/data/890/415/419/890415419.geojson
@@ -19,6 +19,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0643\u0648\u0643\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0643\u0649"
+    ],
+    "name:ceb_x_preferred":[
+        "Koki"
+    ],
     "name:eng_x_preferred":[
         "Koki"
     ],
@@ -26,6 +35,9 @@
         "Koki"
     ],
     "name:ron_x_preferred":[
+        "Koki"
+    ],
+    "name:swe_x_preferred":[
         "Koki"
     ],
     "qs:name":"Koki",
@@ -57,7 +69,7 @@
         }
     ],
     "wof:id":890415419,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938179,
     "wof:name":"Koki",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/427/890415427.geojson
+++ b/data/890/415/427/890415427.geojson
@@ -25,11 +25,17 @@
     "name:ceb_x_preferred":[
         "Itsandra"
     ],
+    "name:deu_x_preferred":[
+        "Itsandra Mdjini"
+    ],
     "name:eng_x_preferred":[
         "Itsandra"
     ],
     "name:fra_x_preferred":[
         "Itsandra"
+    ],
+    "name:fra_x_variant":[
+        "Itsandra Mdjini"
     ],
     "name:nld_x_preferred":[
         "Itsandra"
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890415427,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938180,
     "wof:name":"Itsandra",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/415/431/890415431.geojson
+++ b/data/890/415/431/890415431.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0647\u0648\u0627\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0648\u0627\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0425\u043e\u0430\u043d\u0438"
     ],
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890415431,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938178,
     "wof:name":"Hoani",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/415/433/890415433.geojson
+++ b/data/890/415/433/890415433.geojson
@@ -19,7 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062f\u0632\u064a\u0627\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u0632\u064a\u0627\u0646\u0649"
+    ],
     "name:ceb_x_preferred":[
+        "Dziani"
+    ],
+    "name:deu_x_preferred":[
         "Dziani"
     ],
     "name:eng_x_preferred":[
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890415433,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938180,
     "wof:name":"Dziani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/435/890415435.geojson
+++ b/data/890/415/435/890415435.geojson
@@ -25,8 +25,14 @@
     "name:ceb_x_preferred":[
         "Bouni"
     ],
+    "name:deu_x_preferred":[
+        "Bouni"
+    ],
     "name:eng_x_preferred":[
         "Bouni"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0648\u0646\u06cc \u06a9\u0648\u0645\u0648\u0631\u0648\u0633"
     ],
     "name:fra_x_preferred":[
         "Bouni"
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":890415435,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938181,
     "wof:name":"Bouni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/415/437/890415437.geojson
+++ b/data/890/415/437/890415437.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0646\u062c\u0648\u064a\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0646\u062c\u0648\u064a\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0648\u0646\u0642\u0648\u0626\u0646\u06cc"
     ],
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":890415437,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938178,
     "wof:name":"Boungou\u00e9ni",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/439/890415439.geojson
+++ b/data/890/415/439/890415439.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u064a\u0645\u0628\u064a\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u0645\u0628\u064a\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u06cc\u0645\u0628\u06cc\u0646\u06cc"
     ],
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":890415439,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938178,
     "wof:name":"Bimbini",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/415/443/890415443.geojson
+++ b/data/890/415/443/890415443.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0623\u0633\u064a\u0645\u0628\u0627\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0633\u064a\u0645\u0628\u0627\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0622\u0633\u06cc\u0645\u067e\u0627\u0626\u0648"
     ],
@@ -26,6 +32,9 @@
         "\u0410\u0441\u0438\u043c\u043f\u0430\u043e"
     ],
     "name:ceb_x_preferred":[
+        "Assimpao"
+    ],
+    "name:deu_x_preferred":[
         "Assimpao"
     ],
     "name:eng_x_preferred":[
@@ -70,7 +79,7 @@
         }
     ],
     "wof:id":890415443,
-    "wof:lastmodified":1566581574,
+    "wof:lastmodified":1690938179,
     "wof:name":"Assimpao",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/415/445/890415445.geojson
+++ b/data/890/415/445/890415445.geojson
@@ -19,7 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0623\u0646\u062a\u0633\u0627\u0647\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0646\u062a\u0633\u0627\u0647\u0649"
+    ],
     "name:ceb_x_preferred":[
+        "Antsah\u00e9"
+    ],
+    "name:deu_x_preferred":[
         "Antsah\u00e9"
     ],
     "name:eng_x_preferred":[
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890415445,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938180,
     "wof:name":"Antsah\u00e9",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/415/457/890415457.geojson
+++ b/data/890/415/457/890415457.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0641\u064a\u0646\u0642\u0648\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0641\u064a\u0646\u0642\u0648\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041c\u0430\u0432\u0438\u043d\u0433\u043e\u0443\u043d\u0438"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890415457,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938181,
     "wof:name":"Mavingouni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/415/465/890415465.geojson
+++ b/data/890/415/465/890415465.geojson
@@ -28,11 +28,17 @@
     "name:ceb_x_preferred":[
         "Nioumamilima"
     ],
+    "name:deu_x_preferred":[
+        "Nioumamilima"
+    ],
     "name:eng_x_preferred":[
         "Nioumamilima"
     ],
     "name:fas_x_preferred":[
         "\u0646\u06cc\u0648\u0645\u0627\u0645\u0644\u06cc\u0645\u0627"
+    ],
+    "name:fra_x_preferred":[
+        "Nioumamilima"
     ],
     "name:nld_x_preferred":[
         "Nioumamilima"
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":890415465,
-    "wof:lastmodified":1566581573,
+    "wof:lastmodified":1690938179,
     "wof:name":"Nioumamilima",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/420/059/890420059.geojson
+++ b/data/890/420/059/890420059.geojson
@@ -19,7 +19,13 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u0627\u062a\u0648"
+    ],
     "name:eng_x_preferred":[
+        "Batou"
+    ],
+    "name:gle_x_preferred":[
         "Batou"
     ],
     "name:ita_x_preferred":[
@@ -31,7 +37,13 @@
     "name:nld_x_preferred":[
         "Batou"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0442\u043e"
+    ],
     "name:spa_x_preferred":[
+        "Batou"
+    ],
+    "name:sqi_x_preferred":[
         "Batou"
     ],
     "name:zho_x_preferred":[
@@ -68,7 +80,7 @@
         }
     ],
     "wof:id":890420059,
-    "wof:lastmodified":1566581584,
+    "wof:lastmodified":1690938187,
     "wof:name":"Batou",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/420/071/890420071.geojson
+++ b/data/890/420/071/890420071.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Batsa"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u062a\u0633\u0627"
+    ],
     "name:fra_x_preferred":[
         "Batsa Itsandra"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890420071,
-    "wof:lastmodified":1566581584,
+    "wof:lastmodified":1690938187,
     "wof:name":"Batsa",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/421/821/890421821.geojson
+++ b/data/890/421/821/890421821.geojson
@@ -25,6 +25,18 @@
     "name:eng_x_preferred":[
         "Ntsoudjini"
     ],
+    "name:eng_x_variant":[
+        "N'Tsoudjini"
+    ],
+    "name:fra_x_preferred":[
+        "N'Tsoudjini"
+    ],
+    "name:ind_x_preferred":[
+        "N'Tsoudjini"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30f3\u30c4\u30f4\u30a9\u30b8\u30cb"
+    ],
     "name:nld_x_preferred":[
         "Ntsoudjini"
     ],
@@ -71,7 +83,7 @@
         }
     ],
     "wof:id":890421821,
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1690938185,
     "wof:name":"Ntsoudjini",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/421/823/890421823.geojson
+++ b/data/890/421/823/890421823.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0646\u062a\u0633\u0627\u0648\u064a\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u062a\u0633\u0627\u0648\u064a\u0646\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Ntsaou\u00e9ni"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:ind_x_preferred":[
         "N'Tsaoueni"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30f3\u30c4\u30a1\u30a6\u30a7\u30cb"
     ],
     "name:nld_x_preferred":[
         "Ntsaou\u00e9ni"
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890421823,
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1690938186,
     "wof:name":"Ntsaou\u00e9ni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/421/825/890421825.geojson
+++ b/data/890/421/825/890421825.geojson
@@ -31,6 +31,9 @@
     "name:ceb_x_preferred":[
         "Nioumachoua"
     ],
+    "name:deu_x_preferred":[
+        "Nioumachoua"
+    ],
     "name:eng_x_preferred":[
         "Nioumachoua"
     ],
@@ -46,6 +49,9 @@
     "name:ita_x_preferred":[
         "Nioumachoua"
     ],
+    "name:jpn_x_preferred":[
+        "\u30cb\u30a6\u30de\u30b7\u30e5\u30a2"
+    ],
     "name:nld_x_preferred":[
         "Nioumachoua"
     ],
@@ -54,6 +60,9 @@
     ],
     "name:ron_x_preferred":[
         "Nioumachoua"
+    ],
+    "name:rus_x_preferred":[
+        "\u041d\u044c\u044e\u043c\u0430\u0448\u0443\u0432\u0430"
     ],
     "name:swe_x_preferred":[
         "Nioumachoua"
@@ -88,7 +97,7 @@
         }
     ],
     "wof:id":890421825,
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1690938186,
     "wof:name":"Nioumachoua",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/421/829/890421829.geojson
+++ b/data/890/421/829/890421829.geojson
@@ -34,8 +34,14 @@
     "name:fas_x_preferred":[
         "\u0645\u0631\u0645\u0627\u0646\u06cc"
     ],
+    "name:fra_x_preferred":[
+        "Mr\u00e9mani"
+    ],
     "name:hrv_x_preferred":[
         "Mr\u00e9mani"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e0\u30ec\u30de\u30cb"
     ],
     "name:nld_x_preferred":[
         "Mr\u00e9mani"
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890421829,
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1690938185,
     "wof:name":"Mr\u00e9mani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/421/833/890421833.geojson
+++ b/data/890/421/833/890421833.geojson
@@ -25,7 +25,13 @@
     "name:ceb_x_preferred":[
         "Mramani"
     ],
+    "name:deu_x_preferred":[
+        "Mramani"
+    ],
     "name:eng_x_preferred":[
+        "Mramani"
+    ],
+    "name:fra_x_preferred":[
         "Mramani"
     ],
     "name:hrv_x_preferred":[
@@ -39,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Mramani"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30e0\u30e9\u30de\u30cb"
     ],
     "name:nld_x_preferred":[
         "Mramani"
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":890421833,
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1690938186,
     "wof:name":"Mramani",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/421/843/890421843.geojson
+++ b/data/890/421/843/890421843.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Bambadjani"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0645\u0628\u0627\u062f\u062c\u0627\u0646\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Bambadjani"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890421843,
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1690938185,
     "wof:name":"Bambadjani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/429/477/890429477.geojson
+++ b/data/890/429/477/890429477.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Singani"
     ],
+    "name:deu_x_preferred":[
+        "Singani"
+    ],
     "name:eng_x_preferred":[
         "Singani"
     ],
@@ -29,6 +32,9 @@
         "Singani"
     ],
     "name:nld_x_preferred":[
+        "Singani"
+    ],
+    "name:spa_x_preferred":[
         "Singani"
     ],
     "name:swe_x_preferred":[
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890429477,
-    "wof:lastmodified":1566581584,
+    "wof:lastmodified":1690938187,
     "wof:name":"Singani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/430/551/890430551.geojson
+++ b/data/890/430/551/890430551.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0643\u064a\u0645\u0628\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0645\u0628\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041a\u043e\u0438\u043c\u0431\u0430\u043d\u0438"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:ind_x_preferred":[
         "Koimbani"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30b3\u30a4\u30f3\u30d0\u30cb"
     ],
     "name:nld_x_preferred":[
         "Koimbani"
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":890430551,
-    "wof:lastmodified":1566581575,
+    "wof:lastmodified":1690938181,
     "wof:name":"Koimbani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/430/553/890430553.geojson
+++ b/data/890/430/553/890430553.geojson
@@ -28,6 +28,9 @@
     "name:fas_x_preferred":[
         "\u06a9\u0627\u0646\u06af\u0627\u0646\u06cc"
     ],
+    "name:fra_x_preferred":[
+        "Kangani"
+    ],
     "name:nld_x_preferred":[
         "Kangani"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890430553,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690938182,
     "wof:name":"Kangani",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/430/563/890430563.geojson
+++ b/data/890/430/563/890430563.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0648\u0645\u0648\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0648\u0645\u0648\u0646\u0649"
+    ],
     "name:bre_x_preferred":[
         "Domoni"
     ],
@@ -70,11 +73,20 @@
     "name:ron_x_preferred":[
         "Domoni"
     ],
+    "name:spa_x_preferred":[
+        "Domoni"
+    ],
     "name:srp_x_preferred":[
         "\u0414\u043e\u043c\u043e\u043d\u0438"
     ],
     "name:swe_x_preferred":[
         "Domoni"
+    ],
+    "name:vie_x_preferred":[
+        "Domoni"
+    ],
+    "name:zho_x_preferred":[
+        "\u591a\u6469\u5c3c\u5e02"
     ],
     "qs:name":"Domoni",
     "qs:photos_9r":0,
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":890430563,
-    "wof:lastmodified":1566581577,
+    "wof:lastmodified":1690938182,
     "wof:name":"Domoni",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/431/341/890431341.geojson
+++ b/data/890/431/341/890431341.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u062c\u0648\u064a\u0632\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u064a\u0632\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Djoy\u00e9zi"
+    ],
+    "name:deu_x_preferred":[
+        "Djoiezi"
     ],
     "name:eng_x_preferred":[
         "Djoi\u00e8zi"
@@ -72,7 +78,7 @@
         }
     ],
     "wof:id":890431341,
-    "wof:lastmodified":1566581580,
+    "wof:lastmodified":1690938183,
     "wof:name":"Djoy\u00e9zi",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/431/421/890431421.geojson
+++ b/data/890/431/421/890431421.geojson
@@ -19,10 +19,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0644\u064a\u0645\u0628\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0645\u0628\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0644\u06cc\u0645\u0628\u06cc"
     ],
     "name:ceb_x_preferred":[
+        "Limbi"
+    ],
+    "name:deu_x_preferred":[
         "Limbi"
     ],
     "name:eng_x_preferred":[
@@ -30,6 +39,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0644\u06cc\u0645\u0628\u06cc"
+    ],
+    "name:fra_x_preferred":[
+        "Limbi"
     ],
     "name:nld_x_preferred":[
         "Limbi"
@@ -68,7 +80,7 @@
         }
     ],
     "wof:id":890431421,
-    "wof:lastmodified":1566581580,
+    "wof:lastmodified":1690938183,
     "wof:name":"Limbi",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/432/609/890432609.geojson
+++ b/data/890/432/609/890432609.geojson
@@ -19,13 +19,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0633\u0644\u0627\u0645\u0627\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0633\u0644\u0627\u0645\u0627\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0430\u043b\u0430\u043c\u0430\u043d\u0438"
     ],
     "name:ceb_x_preferred":[
         "Salamani"
     ],
+    "name:deu_x_preferred":[
+        "Salamani"
+    ],
     "name:eng_x_preferred":[
+        "Salamani"
+    ],
+    "name:fra_x_preferred":[
         "Salamani"
     ],
     "name:nld_x_preferred":[
@@ -65,7 +77,7 @@
         }
     ],
     "wof:id":890432609,
-    "wof:lastmodified":1566581590,
+    "wof:lastmodified":1690938191,
     "wof:name":"Salamani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/432/617/890432617.geojson
+++ b/data/890/432/617/890432617.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u064a\u0644\u0627\u0645\u0628\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0644\u0627\u0645\u0628\u0646\u0649"
+    ],
+    "name:ceb_x_preferred":[
+        "Milemb\u00e9ni"
+    ],
     "name:eng_x_preferred":[
         "Mil\u00e9mb\u00e9ni"
     ],
     "name:nld_x_preferred":[
         "Mil\u00e9mb\u00e9ni"
+    ],
+    "name:swe_x_preferred":[
+        "Milemb\u00e9ni"
     ],
     "qs:name":"Milemb\u00e9ni",
     "qs:photos_9r":0,
@@ -56,7 +68,7 @@
         }
     ],
     "wof:id":890432617,
-    "wof:lastmodified":1566581589,
+    "wof:lastmodified":1690938190,
     "wof:name":"Milemb\u00e9ni",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/433/497/890433497.geojson
+++ b/data/890/433/497/890433497.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u062c\u064a\u0645\u0627\u0646\u062f\u0631\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u062c\u064a\u0645\u0627\u0646\u062f\u0631\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Mjimandra"
     ],
@@ -65,7 +71,7 @@
         }
     ],
     "wof:id":890433497,
-    "wof:lastmodified":1566581585,
+    "wof:lastmodified":1690938188,
     "wof:name":"Mjimandra",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/433/583/890433583.geojson
+++ b/data/890/433/583/890433583.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0632\u064a\u0631\u0648\u062f\u0627\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0632\u064a\u0631\u0648\u062f\u0627\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u0417\u0438\u0440\u043e\u0443\u0434\u0430\u043d\u0438"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890433583,
-    "wof:lastmodified":1566581587,
+    "wof:lastmodified":1690938190,
     "wof:name":"Ziroudani",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/433/587/890433587.geojson
+++ b/data/890/433/587/890433587.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0634\u062a\u0631\u0648\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0634\u062a\u0631\u0648\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0686\u06cc\u062a\u0631\u0648\u0646\u06cc"
     ],
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":890433587,
-    "wof:lastmodified":1566581586,
+    "wof:lastmodified":1690938189,
     "wof:name":"Chitrouni",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/433/589/890433589.geojson
+++ b/data/890/433/589/890433589.geojson
@@ -19,10 +19,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u062c\u0646\u0627\u0633\u064a\u0646\u064a \u0646\u064a\u0646\u062f\u0631\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u062c\u0646\u0627\u0633\u064a\u0646\u0649 \u0646\u064a\u0646\u062f\u0631\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Magnassini-Nindri"
     ],
+    "name:deu_x_preferred":[
+        "Magnassini-Nindri"
+    ],
     "name:eng_x_preferred":[
+        "Magnassini-Nindri"
+    ],
+    "name:fra_x_preferred":[
         "Magnassini-Nindri"
     ],
     "name:nld_x_preferred":[
@@ -62,7 +74,7 @@
         }
     ],
     "wof:id":890433589,
-    "wof:lastmodified":1566581586,
+    "wof:lastmodified":1690938189,
     "wof:name":"Magnassini-Nindri",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/433/591/890433591.geojson
+++ b/data/890/433/591/890433591.geojson
@@ -19,7 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062f\u062c\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u062c\u0649"
+    ],
     "name:ceb_x_preferred":[
+        "Daji"
+    ],
+    "name:deu_x_preferred":[
         "Daji"
     ],
     "name:eng_x_preferred":[
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890433591,
-    "wof:lastmodified":1566581586,
+    "wof:lastmodified":1690938189,
     "wof:name":"Daji",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/433/595/890433595.geojson
+++ b/data/890/433/595/890433595.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Mandza"
     ],
+    "name:eng_x_variant":[
+        "Helendje"
+    ],
     "name:nld_x_preferred":[
         "Mandza"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890433595,
-    "wof:lastmodified":1566581585,
+    "wof:lastmodified":1690938188,
     "wof:name":"Mandza",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/433/597/890433597.geojson
+++ b/data/890/433/597/890433597.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0646\u0627\u062f\u062c\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0646\u0627\u062f\u062c\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0646\u062f\u062c\u0648"
     ],
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":890433597,
-    "wof:lastmodified":1566581586,
+    "wof:lastmodified":1690938189,
     "wof:name":"Vanadjou",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/433/601/890433601.geojson
+++ b/data/890/433/601/890433601.geojson
@@ -37,6 +37,9 @@
     "name:ita_x_preferred":[
         "Mvouni"
     ],
+    "name:jpn_x_preferred":[
+        "\u30e0\u30f4\u30cb"
+    ],
     "name:nld_x_preferred":[
         "Mvouni"
     ],
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890433601,
-    "wof:lastmodified":1566581587,
+    "wof:lastmodified":1690938190,
     "wof:name":"Mvouni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/436/599/890436599.geojson
+++ b/data/890/436/599/890436599.geojson
@@ -19,7 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0628\u0627\u0646\u062f\u0627\u062c\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0646\u062f\u0627\u062c\u0648"
+    ],
     "name:ceb_x_preferred":[
+        "Bandajou"
+    ],
+    "name:deu_x_preferred":[
         "Bandajou"
     ],
     "name:eng_x_preferred":[
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890436599,
-    "wof:lastmodified":1566581579,
+    "wof:lastmodified":1690938183,
     "wof:name":"Bandajou",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/438/025/890438025.geojson
+++ b/data/890/438/025/890438025.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Zivandani"
     ],
+    "name:fas_x_preferred":[
+        "\u0632\u06cc\u0648\u0627\u0646\u062f\u0627\u0646\u06cc"
+    ],
     "name:nld_x_preferred":[
         "Zivandani"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890438025,
-    "wof:lastmodified":1566581580,
+    "wof:lastmodified":1690938184,
     "wof:name":"Zivandani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/438/027/890438027.geojson
+++ b/data/890/438/027/890438027.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0645\u064a\u0644\u0627\u0645\u0628\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0644\u0627\u0645\u0628\u0646\u0649"
+    ],
+    "name:ceb_x_preferred":[
+        "Milemb\u00e9ni"
+    ],
     "name:eng_x_preferred":[
         "Mil\u00e9mb\u00e9ni"
     ],
     "name:nld_x_preferred":[
         "Mil\u00e9mb\u00e9ni"
+    ],
+    "name:swe_x_preferred":[
+        "Milemb\u00e9ni"
     ],
     "qs:name":"Milemb\u00e9ni",
     "qs:photos_9r":0,
@@ -56,7 +68,7 @@
         }
     ],
     "wof:id":890438027,
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1690938184,
     "wof:name":"Milemb\u00e9ni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/438/037/890438037.geojson
+++ b/data/890/438/037/890438037.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Vouvouni"
     ],
+    "name:fas_x_preferred":[
+        "\u0648\u0648\u0648\u0648\u0646\u06cc"
+    ],
     "name:swe_x_preferred":[
         "Vouvouni"
     ],
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890438037,
-    "wof:lastmodified":1566581580,
+    "wof:lastmodified":1690938184,
     "wof:name":"Vouvouni",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/438/465/890438465.geojson
+++ b/data/890/438/465/890438465.geojson
@@ -22,7 +22,13 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0627\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0627\u0646\u0649"
+    ],
     "name:ceb_x_preferred":[
+        "Ouani"
+    ],
+    "name:deu_x_preferred":[
         "Ouani"
     ],
     "name:eng_x_preferred":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":890438465,
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1690938184,
     "wof:name":"Ouani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/440/383/890440383.geojson
+++ b/data/890/440/383/890440383.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Bahani"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0627\u0647\u0627\u0646\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Bahani"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890440383,
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1690938176,
     "wof:name":"Bahani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/441/281/890441281.geojson
+++ b/data/890/441/281/890441281.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0648\u0627\u0646\u0627\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0648\u0627\u0646\u0627\u0646\u0649"
+    ],
     "name:bul_x_preferred":[
         "\u041e\u0443\u0430\u043d\u0430\u043d\u0438"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:ind_x_preferred":[
         "Wanani"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30ef\u30ca\u30cb"
     ],
     "name:nld_x_preferred":[
         "Wanani"
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":890441281,
-    "wof:lastmodified":1566581571,
+    "wof:lastmodified":1690938177,
     "wof:name":"Ouanani",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/441/283/890441283.geojson
+++ b/data/890/441/283/890441283.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0641\u0648\u0627\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0641\u0648\u0627\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0648\u0622\u0646\u06cc"
     ],
@@ -28,11 +34,20 @@
     "name:ceb_x_preferred":[
         "Vouani"
     ],
+    "name:deu_x_preferred":[
+        "Vouani"
+    ],
     "name:eng_x_preferred":[
         "Vouani"
     ],
     "name:fas_x_preferred":[
         "\u0648\u0648\u0622\u0646\u06cc"
+    ],
+    "name:fra_x_preferred":[
+        "Vouani"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30f4\u30a2\u30cb"
     ],
     "name:nld_x_preferred":[
         "Vouani"
@@ -74,7 +89,7 @@
         }
     ],
     "wof:id":890441283,
-    "wof:lastmodified":1566581572,
+    "wof:lastmodified":1690938177,
     "wof:name":"Vouani",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/441/285/890441285.geojson
+++ b/data/890/441/285/890441285.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0646\u0627\u0645\u0628\u0648\u064a\u0646\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0641\u0627\u0646\u0627\u0645\u0628\u0648\u064a\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0648\u0646\u0645\u0628\u06cc\u0646\u06cc"
     ],
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":890441285,
-    "wof:lastmodified":1566581572,
+    "wof:lastmodified":1690938177,
     "wof:name":"Vanambouani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/441/733/890441733.geojson
+++ b/data/890/441/733/890441733.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0623\u0648\u0646\u062c\u0648\u0646\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0646\u062c\u0648\u0646\u0649"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0648\u0646\u0642\u0648\u0646\u06cc"
     ],
@@ -26,6 +32,9 @@
         "\u041e\u043d\u0433\u043e\u043d\u0438"
     ],
     "name:ceb_x_preferred":[
+        "Ongoni"
+    ],
+    "name:deu_x_preferred":[
         "Ongoni"
     ],
     "name:eng_x_preferred":[
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":890441733,
-    "wof:lastmodified":1566581572,
+    "wof:lastmodified":1690938177,
     "wof:name":"Ongoni",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/442/265/890442265.geojson
+++ b/data/890/442/265/890442265.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062a\u0634\u064a\u0631\u0648\u0646\u0643\u0627\u0645\u0628\u0627"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u0634\u064a\u0631\u0648\u0646\u0643\u0627\u0645\u0628\u0627"
+    ],
     "name:azb_x_preferred":[
         "\u0686\u06cc\u0631\u0648\u0646 \u06a9\u0627\u0645\u0628\u0627"
     ],
@@ -33,6 +39,9 @@
     ],
     "name:fra_x_preferred":[
         "Chironkamba"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30d0\u30f3\u30c9\u30e9\u30cb\uff1d\u30b7\u30ed\u30f3\u30ab\u30f3\u30d0"
     ],
     "name:nld_x_preferred":[
         "Chironkamba"
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":890442265,
-    "wof:lastmodified":1566581585,
+    "wof:lastmodified":1690938188,
     "wof:name":"Chironkamba",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/442/415/890442415.geojson
+++ b/data/890/442/415/890442415.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0631\u0648\u0646\u062a\u0633\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0631\u0648\u0646\u062a\u0633\u0649"
+    ],
     "name:ceb_x_preferred":[
         "Mirontsi"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:ita_x_preferred":[
         "Mirontsi"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30df\u30ed\u30f3\u30b7"
     ],
     "name:nld_x_preferred":[
         "Mirontsi"
@@ -86,7 +92,7 @@
         }
     ],
     "wof:id":890442415,
-    "wof:lastmodified":1566581585,
+    "wof:lastmodified":1690938187,
     "wof:name":"Mirontsi",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/443/479/890443479.geojson
+++ b/data/890/443/479/890443479.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Chindini"
     ],
+    "name:fas_x_preferred":[
+        "\u0686\u06cc\u0646\u062f\u06cc\u0646\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Chindini"
     ],
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890443479,
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1690938186,
     "wof:name":"Chindini",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/443/481/890443481.geojson
+++ b/data/890/443/481/890443481.geojson
@@ -31,6 +31,9 @@
     "name:ind_x_preferred":[
         "Chezani"
     ],
+    "name:jpn_x_preferred":[
+        "\u30c1\u30a7\u30b6\u30cb"
+    ],
     "name:nld_x_preferred":[
         "Chezani"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890443481,
-    "wof:lastmodified":1566581584,
+    "wof:lastmodified":1690938187,
     "wof:name":"Chezani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/453/993/890453993.geojson
+++ b/data/890/453/993/890453993.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Douniani"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u0648\u0646\u06cc\u0627\u0646\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Douniani"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890453993,
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1690938185,
     "wof:name":"Douniani",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",

--- a/data/890/455/811/890455811.geojson
+++ b/data/890/455/811/890455811.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Vassy"
     ],
+    "name:deu_x_preferred":[
+        "Vassy"
+    ],
     "name:eng_x_preferred":[
         "Vassi"
     ],
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890455811,
-    "wof:lastmodified":1566581578,
+    "wof:lastmodified":1690938182,
     "wof:name":"Vassy",
     "wof:parent_id":85670277,
     "wof:placetype":"locality",

--- a/data/890/455/813/890455813.geojson
+++ b/data/890/455/813/890455813.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Sambia"
     ],
+    "name:fra_x_preferred":[
+        "Sambia"
+    ],
     "name:nld_x_preferred":[
         "Sambia"
     ],
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890455813,
-    "wof:lastmodified":1566581579,
+    "wof:lastmodified":1690938182,
     "wof:name":"Sambia",
     "wof:parent_id":85670267,
     "wof:placetype":"locality",

--- a/data/890/455/819/890455819.geojson
+++ b/data/890/455/819/890455819.geojson
@@ -25,6 +25,9 @@
     "name:ben_x_preferred":[
         "\u09aa\u09be\u09a8\u09cd\u09a1\u09be"
     ],
+    "name:ceb_x_preferred":[
+        "Panda"
+    ],
     "name:deu_x_preferred":[
         "Panda"
     ],
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890455819,
-    "wof:lastmodified":1636501335,
+    "wof:lastmodified":1690938182,
     "wof:name":"Panda",
     "wof:parent_id":85670273,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.