### PR TITLE
km concordances, placetype local, and more

### DIFF
--- a/data/856/322/59/85632259.geojson
+++ b/data/856/322/59/85632259.geojson
@@ -1225,6 +1225,7 @@
         "hasc:id":"KM",
         "icao:code":"D6",
         "ioc:id":"COM",
+        "iso:code":"KM",
         "itu:id":"COM",
         "loc:id":"n80033810",
         "m49:code":"174",
@@ -1239,6 +1240,7 @@
         "wk:page":"Comoros",
         "wmo:id":"IC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KM",
     "wof:country_alpha3":"COM",
     "wof:geom_alt":[
@@ -1264,7 +1266,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1694639532,
+    "wof:lastmodified":1695881189,
     "wof:name":"Comoros",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/702/67/85670267.geojson
+++ b/data/856/702/67/85670267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016534,
-    "geom:area_square_m":199746434.459844,
+    "geom:area_square_m":199747282.588966,
     "geom:bbox":"43.629893,-12.373468,43.861583,-12.236912",
     "geom:latitude":-12.314737,
     "geom:longitude":43.728401,
@@ -307,13 +307,15 @@
         "gn:id":921780,
         "gp:id":2345045,
         "hasc:id":"KM.MO",
+        "iso:code":"KM-M",
         "iso:id":"KM-M",
         "qs_pg:id":229367,
         "wd:id":"Q271797",
         "wk:page":"Moh\u00e9li"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KM",
-    "wof:geomhash":"bcd5f26b378b38210c426224d7b9a18d",
+    "wof:geomhash":"e841a8a9afc9d12820622dca651d52b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -332,7 +334,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1690938173,
+    "wof:lastmodified":1695884501,
     "wof:name":"Mo\u00fbh\u00eel\u00ee",
     "wof:parent_id":85632259,
     "wof:placetype":"region",

--- a/data/856/702/73/85670273.geojson
+++ b/data/856/702/73/85670273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084952,
-    "geom:area_square_m":1028783101.365624,
+    "geom:area_square_m":1028781970.349017,
     "geom:bbox":"43.213227,-11.932875,43.49879,-11.361261",
     "geom:latitude":-11.655424,
     "geom:longitude":43.339728,
@@ -208,12 +208,14 @@
         "gn:id":921882,
         "gp:id":2345044,
         "hasc:id":"KM.GC",
+        "iso:code":"KM-G",
         "iso:id":"KM-G",
         "qs_pg:id":219530,
         "unlc:id":"KM-G"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KM",
-    "wof:geomhash":"de2fef453217f4ec07485123249d0b59",
+    "wof:geomhash":"2b12c5629cd18b2281a1a0b6af8c9557",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -232,7 +234,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1614893624,
+    "wof:lastmodified":1695884501,
     "wof:name":"Andjaz\u00eedja",
     "wof:parent_id":85632259,
     "wof:placetype":"region",

--- a/data/856/702/77/85670277.geojson
+++ b/data/856/702/77/85670277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037266,
-    "geom:area_square_m":450368793.875425,
+    "geom:area_square_m":450369384.233089,
     "geom:bbox":"44.206391,-12.380304,44.529063,-12.064142",
     "geom:latitude":-12.21476,
     "geom:longitude":44.434825,
@@ -334,14 +334,16 @@
         "gn:id":922001,
         "gp:id":2345043,
         "hasc:id":"KM.AN",
+        "iso:code":"KM-A",
         "iso:id":"KM-A",
         "qs_pg:id":59600,
         "unlc:id":"KM-A",
         "wd:id":"Q231324",
         "wk:page":"Anjouan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KM",
-    "wof:geomhash":"b529ed217a475a8ed8b63c85764cb48a",
+    "wof:geomhash":"84f4b2cdd396189f08ebe60c8144b7a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -360,7 +362,7 @@
         "fra",
         "zdj"
     ],
-    "wof:lastmodified":1690938174,
+    "wof:lastmodified":1695884501,
     "wof:name":"Andjou\u00e2n",
     "wof:parent_id":85632259,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.